### PR TITLE
修改 styled-components 的路徑

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import ServiceIntroCompile from './pages/ServiceIntroCompile';
 

--- a/src/components/edit/blockInputFields/FullWidthTextInput.js
+++ b/src/components/edit/blockInputFields/FullWidthTextInput.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const TextAreaWrapper = styled.div`
   width: 80%;

--- a/src/components/edit/blockInputFields/SideImageField.js
+++ b/src/components/edit/blockInputFields/SideImageField.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import blockImageUpload from '../../../utils/firebase/blockImageUpload';
 import ImagePlaceholder from '../templateInputFields/ImagePlaceholder';

--- a/src/components/edit/blockInputFields/SideTextInput.js
+++ b/src/components/edit/blockInputFields/SideTextInput.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const TextAreaWrapper = styled.div`
   width: 40%;

--- a/src/components/edit/templateInputFields/ContactInputFields.js
+++ b/src/components/edit/templateInputFields/ContactInputFields.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';
 

--- a/src/components/edit/templateInputFields/HeroImageField.js
+++ b/src/components/edit/templateInputFields/HeroImageField.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import singleImageUpload from '../../../utils/firebase/singleImageUpload';
 import { randomLinearGradient } from '../../../utils/data/linearGradient';

--- a/src/components/edit/templateInputFields/ImagePlaceholder.js
+++ b/src/components/edit/templateInputFields/ImagePlaceholder.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { ImageIcon } from '../../../utils/icons';
 import { lightLinearGradients } from '../../../utils/data/linearGradient';

--- a/src/components/edit/templateInputFields/ImageWallField.js
+++ b/src/components/edit/templateInputFields/ImageWallField.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import uuid from 'react-uuid';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import ImagePlaceholder from './ImagePlaceholder';
 import multipleImagesUpload from '../../../utils/firebase/multipleImageUpload';

--- a/src/components/edit/templateInputFields/ServiceProvideCityInput.js
+++ b/src/components/edit/templateInputFields/ServiceProvideCityInput.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import uuid from 'react-uuid';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';
 import CheckBox from './CheckBox';

--- a/src/components/edit/templateInputFields/TagArea.js
+++ b/src/components/edit/templateInputFields/TagArea.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import uuid from 'react-uuid';
 
 import { CloseIcon } from '../../../utils/icons';

--- a/src/components/preview/blockItems/FullWidthText.js
+++ b/src/components/preview/blockItems/FullWidthText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const Paragraph = styled.p`
   white-space: pre-wrap;

--- a/src/components/preview/blockItems/SideImage.js
+++ b/src/components/preview/blockItems/SideImage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import ImagePlaceholder from '../../edit/templateInputFields/ImagePlaceholder';
 

--- a/src/components/preview/blockItems/SideText.js
+++ b/src/components/preview/blockItems/SideText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const TextWrapper = styled.div`
   display: flex;

--- a/src/components/preview/templateItems/ContactInfoArea.js
+++ b/src/components/preview/templateItems/ContactInfoArea.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';
 

--- a/src/components/preview/templateItems/HeroImage.js
+++ b/src/components/preview/templateItems/HeroImage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { randomLinearGradient } from '../../../utils/data/linearGradient';
 import { HeroImageContainer } from '../../../styles/layout/TemplateLayout';

--- a/src/components/preview/templateItems/ImagesWall.js
+++ b/src/components/preview/templateItems/ImagesWall.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import uuid from 'react-uuid';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';

--- a/src/components/preview/templateItems/IntroParagraph.js
+++ b/src/components/preview/templateItems/IntroParagraph.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';
 

--- a/src/components/preview/templateItems/KeywordTags.js
+++ b/src/components/preview/templateItems/KeywordTags.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import uuid from 'react-uuid';
 
 import { SectionWrapper } from '../../../styles/layout/TemplateLayout';

--- a/src/components/templates/ToggleSwitch.js
+++ b/src/components/templates/ToggleSwitch.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 const Switch = styled.label`
   position: fixed;

--- a/src/pages/ServiceIntroCompile.js
+++ b/src/pages/ServiceIntroCompile.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 import ToggleSwitch from '../components/templates/ToggleSwitch';
 import TemplateArea from '../components/templates/TemplateArea';

--- a/src/styles/BlockContainer.js
+++ b/src/styles/BlockContainer.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components/macro';
+
+const BlockContainer = styled.div`
+  display: flex;
+  width: 80%;
+  max-width: 1200px;
+  height: 250px;
+  justify-content: center;
+  align-items: flex-start;
+  margin-bottom: 50px;
+`;
+
+export default BlockContainer;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components/macro';
 
 const GlobalStyles = createGlobalStyle`
 

--- a/src/styles/layout/TemplateLayout.js
+++ b/src/styles/layout/TemplateLayout.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const SectionWrapper = styled.div`
   margin: 30px auto;

--- a/src/styles/sharedStyledComponents/ButtonStyle.js
+++ b/src/styles/sharedStyledComponents/ButtonStyle.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Button = styled.button`
   background-color: #fff;


### PR DESCRIPTION
其實可以用 babel-plugin-styled-components 這個套件讓你開發時，看到你命名的 component 的名字，不過我怎麼配置 babel 的設定檔都沒辦法 work，所以用另外一個方法引入 macro。
<img width="1440" alt="截圖 2021-07-07 下午11 08 30" src="https://user-images.githubusercontent.com/40907984/124785897-d86d2300-df79-11eb-8fc7-998d4c8c83a9.png">

參考文件：https://styled-components.com/docs/tooling#babel-macro